### PR TITLE
Remove these enums as they are already defined elsewhere

### DIFF
--- a/src/main/protobuf/CommonModelMessages.proto
+++ b/src/main/protobuf/CommonModelMessages.proto
@@ -40,19 +40,3 @@ message ProtoDoubleRange {
     optional double from = 1;
     optional double to = 2;
 }
-
-enum ProtoTradeSide {
-    BUY = 1;
-    SELL = 2;
-}
-
-enum ProtoQuoteType {
-    BID = 1;
-    ASK = 2;
-}
-
-enum ProtoTimeInForce {
-    GOOD_TILL_DATE = 1;
-    GOOD_TILL_CANCEL = 2;
-    IMMEDIATE_OR_CANCEL = 3;
-}


### PR DESCRIPTION
The latest changes redefine some existing enums, which causes issues when compiling.

This removes the duplicates.